### PR TITLE
feat(worktree): add worktree skill and WorktreeCreate hook

### DIFF
--- a/private_dot_claude/hooks/executable_worktree-create.sh
+++ b/private_dot_claude/hooks/executable_worktree-create.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# WorktreeCreate hook: creates a git worktree and copies env files + local settings.
+# Replaces Claude Code's default git worktree behavior.
+#
+# Input (stdin JSON): { "name": "<slug>", "cwd": "<path>", ... }
+# Output (stdout):    absolute path to the created worktree directory
+# All diagnostic output goes to stderr.
+#
+# Worktree path convention: .claude/worktrees/<name> under the main worktree root.
+# This path is also referenced in skills/worktree/SKILL.md — keep them in sync.
+
+set -euo pipefail
+
+# --- Dependency check ---
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: worktree-create hook requires jq. Install with: brew install jq" >&2
+  exit 1
+fi
+
+# --- Parse and validate input ---
+
+INPUT=$(cat)
+NAME=$(echo "$INPUT" | jq -r '.name // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+echo "WorktreeCreate hook: name=$NAME cwd=$CWD" >&2
+
+if [ -z "$NAME" ]; then
+  echo "Error: missing or empty 'name' in hook input" >&2
+  exit 1
+fi
+
+if ! git check-ref-format --branch "$NAME" >/dev/null 2>&1; then
+  echo "Error: invalid branch/worktree name: $NAME" >&2
+  exit 1
+fi
+
+if [ -z "$CWD" ]; then
+  CWD="$(pwd)"
+fi
+
+# --- Find the main worktree ---
+
+MAIN_WORKTREE=$(git -C "$CWD" worktree list --porcelain | grep '^worktree ' | head -1 | sed 's/^worktree //')
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "Error: could not determine main worktree path (is this a git repo?)" >&2
+  exit 1
+fi
+
+WORKTREE_DIR="$MAIN_WORKTREE/.claude/worktrees/$NAME"
+
+# --- Create the git worktree ---
+
+if [ -d "$WORKTREE_DIR" ]; then
+  echo "Error: worktree directory already exists: $WORKTREE_DIR" >&2
+  exit 1
+fi
+
+# Track whether we created a new branch so cleanup can remove it
+CREATED_BRANCH=false
+
+# Clean up on failure so we don't leave orphaned worktrees or branches
+cleanup() {
+  echo "Error during worktree setup; cleaning up" >&2
+  if git -C "$CWD" worktree remove --force "$WORKTREE_DIR" 2>/dev/null; then
+    echo "  Removed worktree $WORKTREE_DIR" >&2
+  else
+    echo "  Warning: could not remove worktree $WORKTREE_DIR" >&2
+  fi
+  if [ "$CREATED_BRANCH" = "true" ]; then
+    if git -C "$CWD" branch -D "$NAME" 2>/dev/null; then
+      echo "  Removed branch $NAME" >&2
+    fi
+  fi
+}
+trap cleanup ERR
+
+if git -C "$CWD" rev-parse --verify "refs/heads/$NAME" >/dev/null 2>&1; then
+  # Branch already exists — check it out into the new worktree
+  git -C "$CWD" worktree add "$WORKTREE_DIR" "$NAME" >&2
+else
+  # Create a new branch from HEAD
+  CREATED_BRANCH=true
+  git -C "$CWD" worktree add "$WORKTREE_DIR" -b "$NAME" HEAD >&2
+fi
+
+# --- Copy env files and local settings ---
+
+COPIED=0
+
+copy_if_exists() {
+  local src="$1"
+  local dst="$2"
+  if [ -f "$src" ]; then
+    mkdir -p "$(dirname "$dst")"
+    cp "$src" "$dst"
+    echo "  Copied $(echo "$dst" | sed "s|^$WORKTREE_DIR/||")" >&2
+    COPIED=$((COPIED + 1))
+  fi
+}
+
+copy_env_from_dir() {
+  local src_dir="$1"
+  local dst_dir="$2"
+
+  copy_if_exists "$src_dir/.env" "$dst_dir/.env"
+  copy_if_exists "$src_dir/.env.local" "$dst_dir/.env.local"
+
+  for f in "$src_dir"/.env.*.local; do
+    [ -f "$f" ] || continue
+    copy_if_exists "$f" "$dst_dir/$(basename "$f")"
+  done
+}
+
+# Root env files
+copy_env_from_dir "$MAIN_WORKTREE" "$WORKTREE_DIR"
+
+# .claude/settings.local.json
+copy_if_exists "$MAIN_WORKTREE/.claude/settings.local.json" "$WORKTREE_DIR/.claude/settings.local.json"
+
+# pnpm workspace packages
+MAX_WORKSPACE_PATTERNS=50
+if [ -f "$MAIN_WORKTREE/pnpm-workspace.yaml" ]; then
+  # Extract list items from the packages: section only.
+  # Stop at the next top-level key (line starting with a non-space, non-comment, non-dash character).
+  PACKAGE_LINES=$(grep -A 1000 '^packages:' "$MAIN_WORKTREE/pnpm-workspace.yaml" 2>/dev/null \
+    | tail -n +2 \
+    | awk '/^[^[:space:]#-]/ { exit } /^[[:space:]]*-/ { print }' \
+    || true)
+
+  PATTERN_COUNT=$(echo "$PACKAGE_LINES" | grep -c . || true)
+  if [ "$PATTERN_COUNT" -gt "$MAX_WORKSPACE_PATTERNS" ]; then
+    echo "Warning: found $PATTERN_COUNT workspace patterns; only processing first $MAX_WORKSPACE_PATTERNS" >&2
+  fi
+
+  while IFS= read -r line; do
+    pattern=$(echo "$line" | sed "s/^[[:space:]]*-[[:space:]]*//; s/['\"]//g; s/[[:space:]]*$//")
+    [ -z "$pattern" ] && continue
+    [[ "$pattern" == !* ]] && continue
+
+    # Expand the glob pattern relative to the main worktree.
+    # Quote the prefix to handle spaces; leave $pattern unquoted for glob expansion.
+    matched=0
+    for pkg_dir in "$MAIN_WORKTREE"/$pattern; do
+      [ -d "$pkg_dir" ] || continue
+      matched=$((matched + 1))
+      rel_pkg="${pkg_dir#$MAIN_WORKTREE/}"
+      copy_env_from_dir "$pkg_dir" "$WORKTREE_DIR/$rel_pkg"
+    done
+    if [ "$matched" -eq 0 ]; then
+      echo "  Warning: workspace pattern '$pattern' matched no directories" >&2
+    fi
+  done < <(echo "$PACKAGE_LINES" | head -"$MAX_WORKSPACE_PATTERNS")
+fi
+
+if [ "$COPIED" -gt 0 ]; then
+  echo "Copied $COPIED file(s) to worktree" >&2
+else
+  echo "No env files found to copy" >&2
+fi
+
+# Disable the ERR trap now that setup is complete
+trap - ERR
+
+# --- Output the worktree path (Claude Code reads this from stdout) ---
+echo "Emitting worktree path: $WORKTREE_DIR" >&2
+echo "$WORKTREE_DIR"

--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -60,6 +60,16 @@
           }
         ]
       }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/worktree-create.sh"
+          }
+        ]
+      }
     ]
   },
   "alwaysThinkingEnabled": true,

--- a/private_dot_claude/skills/worktree/SKILL.md
+++ b/private_dot_claude/skills/worktree/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: worktree
+description: Use when the user says "/worktree", "create a worktree for X", or "set up a worktree named X". Manages git worktrees with automatic env file copying.
+version: 1.0.0
+---
+
+# Worktree
+
+Manage git worktrees without memorizing syntax. Env files and local settings are copied automatically.
+
+## Commands
+
+### Create
+
+**Trigger:** `/worktree <name>` or `/worktree create <name>`
+
+Use the built-in `EnterWorktree` tool:
+
+```
+EnterWorktree(name: "<name>")
+```
+
+The `WorktreeCreate` hook in `~/.claude/settings.json` runs automatically and:
+
+1. Creates a git worktree at `.claude/worktrees/<name>` with a new branch
+2. Copies `.env`, `.env.local`, `.env.*.local` from the main worktree root
+3. Copies `.claude/settings.local.json`
+4. Detects `pnpm-workspace.yaml` and copies env files from workspace package directories
+
+After creation, the session switches to the new worktree directory.
+
+Report what was created and which files were copied.
+
+### List
+
+**Trigger:** `/worktree list`
+
+```bash
+git worktree list
+```
+
+Worktrees created via this skill appear under `.claude/worktrees/` in the output.
+
+### Remove
+
+**Trigger:** `/worktree remove <name>`
+
+First find the main worktree root, then remove by absolute path:
+
+```bash
+MAIN=$(git worktree list --porcelain | grep '^worktree ' | head -1 | sed 's/^worktree //')
+git worktree remove "$MAIN/.claude/worktrees/<name>"
+```
+
+If the branch was created by the worktree, offer to delete it:
+
+```bash
+git branch -d <name>
+```
+
+Use `-d` (safe delete, only if merged). If the user explicitly wants to force-delete an unmerged branch, use `-D` after confirming.
+
+## What Gets Copied
+
+| Source pattern | Where copied from |
+| --- | --- |
+| `.env` | Root and each pnpm workspace package |
+| `.env.local` | Root and each pnpm workspace package |
+| `.env.*.local` | Root and each pnpm workspace package |
+| `.claude/settings.local.json` | Root only |
+
+Workspace packages are discovered by reading glob patterns from `pnpm-workspace.yaml`. Negation patterns (starting with `!`) are skipped.
+
+Files like `.env.development` or `.env.test` (without `.local`) are not copied. Only `.local` variants and the base `.env` are included.
+
+## Error Handling
+
+| Failure | Recovery |
+| --- | --- |
+| `EnterWorktree` fails | Report the error. Suggest running `git worktree list` to check state. |
+| Hook exits non-zero | Include stderr output in report. Do not proceed as if the worktree is ready. The hook cleans up orphaned worktrees on failure. |
+| Name is invalid for git | Report that the name must be a valid git branch name. |
+
+## Notes
+
+- The hook only fires when a worktree is created via `claude --worktree`, `EnterWorktree`, or `isolation: "worktree"` subagents. Direct `git worktree add` commands bypass the hook.
+- If a branch with the given name already exists, it is checked out (not recreated).
+- The worktree is stored under `.claude/worktrees/` in the main worktree root.
+- On session exit, Claude Code may prompt to keep or remove the worktree.


### PR DESCRIPTION
## Summary

- Add `/worktree` skill for creating, listing, and removing git worktrees without memorizing syntax
- Add `WorktreeCreate` hook that replaces Claude Code's default behavior to automatically copy `.env`, `.env.local`, `.env.*.local`, and `.claude/settings.local.json` into new worktrees
- Detect pnpm workspaces and copy env files from workspace package directories

## Research

Surveyed existing tools before building: [worktrunk](https://worktrunk.dev/), [wtp](https://github.com/satococoa/wtp), [git-worktree-runner](https://github.com/coderabbitai/git-worktree-runner), [envi](https://envi.codecompose.dev/), [@adamhancock/worktree](https://www.npmjs.com/package/@adamhancock/worktree), and Claude Code's native `--worktree` flag. None integrate env file copying into Claude Code's `WorktreeCreate` hook lifecycle, which is the gap this fills.

## Test Plan

- [ ] Run `chezmoi apply` to deploy files to `~/.claude/`
- [ ] In any git repo: `claude --worktree` or invoke `/worktree my-feature` — verify worktree is created and env files are copied
- [ ] In a pnpm workspace project: verify env files from workspace packages are copied
- [ ] Test with an invalid name (e.g., containing `..`) — verify it is rejected
- [ ] Test removal via `/worktree remove <name>`

## Review Notes

Self-reviewed via deliver skill (2 review cycles, 5 reviewers each).

Known limitations:
- pnpm-workspace.yaml parsing uses grep+awk, not a full YAML parser. Stops at the next top-level key but does not handle flow-style arrays or YAML anchors. Capped at 50 workspace patterns.
- Only copies `.env`, `.env.local`, and `.env.*.local` — not `.env.development`, `.env.test`, `.npmrc`, etc. (deliberate scope choice per user request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)