### PR TITLE
feat(deliver): use /git-commit-message for commits

### DIFF
--- a/private_dot_claude/skills/deliver/SKILL.md
+++ b/private_dot_claude/skills/deliver/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deliver
 description: This skill should be used when the user asks to "deliver this", "implement and PR", "build this feature", "fix this bug and open a PR", "/deliver", or wants autonomous end-to-end implementation from understanding through pull request.
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Deliver
@@ -105,26 +105,16 @@ Before committing, run the project's quality checks so issues are caught before 
 
 ### Commit
 
-```bash
-git add [specific files]
-git commit -m "$(cat <<'EOF'
-type(scope): short description
-
-Longer description if needed.
-
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
-EOF
-)"
-```
-
-Use conventional commit format: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`.
+Stage specific files with `git add`, then follow the `/git-commit-message` skill to generate and create the commit. When gathering context for Step 1, use the review findings and conversation summary from this session. Since `/deliver` operates autonomously, auto-accept the generated message — skip the "Yes / Revise / Regenerate" prompt in `/git-commit-message` Step 3.
 
 ### Push and PR
+
+Use `git log -1 --format='%s'` to retrieve the committed subject line for the PR title.
 
 ```bash
 git push -u origin HEAD
 
-gh pr create --title "type(scope): short description" --body "$(cat <<'EOF'
+gh pr create --title "$(git log -1 --format='%s')" --body "$(cat <<'EOF'
 ## Summary
 
 [1-3 bullets]


### PR DESCRIPTION
## Summary

- Rewire the `/deliver` skill's Commit step to delegate to `/git-commit-message` instead of inlining a hard-coded commit template
- PR title now uses the actual committed subject line via `git log -1 --format='%s'` instead of a placeholder
- Bump skill version to 1.1.0

## Test Plan

- [ ] Run `/deliver` on a small task and verify it invokes `/git-commit-message` for the commit step
- [ ] Verify the auto-accept instruction prevents the approval prompt from pausing the flow
- [ ] Verify the PR title matches the commit subject line

## Review Notes

Self-reviewed via deliver skill.
3 reviewers (Architect, User-Advocate, Adversary) ran in parallel. All CRITICAL/HIGH findings addressed except:
- Error Recovery table not updated for sub-skill failures (rebutted: covered by existing general principle)
- No guard against empty staging (rebutted: /git-commit-message handles this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)