### PR TITLE
feat(git): add branch-memo script, bm alias, and /branch-memo skill

### DIFF
--- a/bin/executable_git-branch-memo
+++ b/bin/executable_git-branch-memo
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# git-branch-memo: attach a human-readable note to the current branch
+#
+# Usage:
+#   git branch-memo [<message>]
+#   git bm [<message>]
+#
+# With no arguments, displays existing memos and prompts for a message.
+# With a message argument, creates the memo immediately.
+#
+# Memos are empty commits with a "memo:" prefix, making them:
+#   - visible in: git log --oneline
+#   - filterable: git log --oneline --grep="^memo:"
+#   - rebase-safe (preserve them with `pick` during interactive rebase)
+
+set -euo pipefail
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+if [[ -t 1 ]]; then
+  BOLD='\033[1m' DIM='\033[2m' NC='\033[0m'
+else
+  BOLD='' DIM='' NC=''
+fi
+
+info()  { printf "${BOLD}%s${NC}\n" "$*"; }
+dim()   { printf "${DIM}%s${NC}\n" "$*"; }
+error() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+# ── Preflight ─────────────────────────────────────────────────────────────────
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) \
+  || error "not inside a git repository"
+[[ "$branch" == "HEAD" ]] && error "detached HEAD — check out a branch first"
+
+# Refuse to write memo when there are staged changes (they'd be included or
+# the empty-commit would conflict with the index state).
+if ! git diff --cached --quiet; then
+  error "cannot write memo when there are staged changes — commit or reset them first"
+fi
+
+# ── Show existing memos ───────────────────────────────────────────────────────
+existing=$(git log --oneline --grep="^memo:" "$(git merge-base HEAD origin/main 2>/dev/null || git rev-parse HEAD)"..HEAD 2>/dev/null || true)
+if [[ -n "$existing" ]]; then
+  info "Existing memos on ${branch}:"
+  while IFS= read -r line; do
+    dim "  $line"
+  done <<< "$existing"
+  printf '\n'
+fi
+
+# ── Get the message ───────────────────────────────────────────────────────────
+# $@ is the message passed from the caller (Claude Code strips "branch-memo"
+# before forwarding args when invoked as `git branch-memo <msg>`).
+if [[ $# -gt 0 ]]; then
+  message="$*"
+else
+  printf 'Memo message: '
+  IFS= read -r message
+fi
+
+[[ -z "$message" ]] && error "memo message cannot be empty"
+
+# Strip a leading "memo:" if the caller already included it, then re-add it
+# so the prefix is always exactly "memo: " (one space, consistent grep target).
+message="${message#memo:}"
+message="${message#memo: }"
+message="memo: ${message# }"  # trim any leading space left after stripping
+
+# ── Create the empty commit ───────────────────────────────────────────────────
+git commit --allow-empty -m "$message"
+
+printf '\n'
+info "Memo recorded on ${branch}:"
+git log --oneline -1

--- a/bin/executable_git-branch-memo
+++ b/bin/executable_git-branch-memo
@@ -63,10 +63,35 @@ fi
 # so the prefix is always exactly "memo: " (one space, consistent grep target).
 message="${message#memo:}"
 message="${message#memo: }"
-message="memo: ${message# }"  # trim any leading space left after stripping
+message="${message# }"  # trim any leading space left after stripping
+
+# ── Word-wrap ─────────────────────────────────────────────────────────────────
+# Subject line (incl. "memo: " prefix): ≤ 50 chars.
+# Body continuation lines: ≤ 72 chars.
+# Long tokens (e.g. URLs) are never broken mid-word.
+_wrap_memo() {
+  local text="$1" max=50 line="" first=1 out=""
+  local -a words
+  read -ra words <<< "memo: ${text}"
+  for word in "${words[@]}"; do
+    if [[ -z "$line" ]]; then
+      line="$word"
+    elif (( ${#line} + 1 + ${#word} <= max )); then
+      line+=" $word"
+    else
+      out+="${line}"$'\n'
+      if (( first )); then out+=$'\n'; first=0; max=72; fi
+      line="$word"
+    fi
+  done
+  [[ -n "$line" ]] && out+="${line}"
+  printf '%s' "$out"
+}
+
+formatted=$(_wrap_memo "$message")
 
 # ── Create the empty commit ───────────────────────────────────────────────────
-git commit --allow-empty -m "$message"
+git commit --allow-empty -m "$formatted"
 
 printf '\n'
 info "Memo recorded on ${branch}:"

--- a/private_dot_claude/skills/branch-memo/SKILL.md
+++ b/private_dot_claude/skills/branch-memo/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: branch-memo
+description: This skill should be used when the user says "/branch-memo", "add a branch memo", "leave a note on this branch", or wants to annotate the current branch with a human-readable memo commit.
+version: 1.0.0
+---
+
+# Branch Memo
+
+Attach a human-readable note to the current branch as an empty commit.
+Memos survive rebases and appear in `git log`, giving branches a
+self-describing audit trail useful for cleanup and review.
+
+## Invocation
+
+- `/branch-memo` — show existing memos, then prompt for a message
+- `/branch-memo <message>` — record the memo immediately
+
+## Behavior
+
+### Step 1: Show existing memos
+
+Run:
+
+```bash
+git log --oneline --grep="^memo:" "$(git merge-base HEAD origin/main)"..HEAD
+```
+
+Display any memos found. If none, note that this is the first memo on the
+branch.
+
+### Step 2: Get the message
+
+- If the user provided a message in the invocation arguments, use it directly.
+- If not, ask the user for a message before proceeding.
+
+The message must not be empty.
+
+### Step 3: Create the memo
+
+Run the `git-branch-memo` script (available as `git branch-memo` or `git bm`):
+
+```bash
+git branch-memo "<message>"
+```
+
+The script prepends `memo:` automatically — do not add it yourself.
+
+If the script exits non-zero (staged changes, detached HEAD, empty message),
+surface the error output and stop.
+
+### Step 4: Confirm
+
+Show the user the resulting `git log --oneline -1` output so they can see
+the recorded memo.
+
+## Example
+
+```
+User: /branch-memo waiting for design sign-off before merging
+
+Existing memos on feat/checkout-redesign:
+  a1b2c3d memo: initial spike — needs UX review
+
+Memo recorded on feat/checkout-redesign:
+  d4e5f6a memo: waiting for design sign-off before merging
+```
+
+## Error Handling
+
+| Failure | Recovery |
+| --- | --- |
+| Staged changes exist | Inform the user; do not create the memo |
+| Detached HEAD | Inform the user; do not create the memo |
+| Empty message | Ask the user for a non-empty message |
+| `git-branch-memo` not found | Remind the user to apply chezmoi (`chezmoi apply`) so `~/bin/git-branch-memo` is present |

--- a/private_dot_gitconfig
+++ b/private_dot_gitconfig
@@ -2,6 +2,7 @@
 	add-aw = "!git diff -w --no-color | git apply --cached --ignore-whitespace"
 	amend = commit --amend
 	branchname = "!f() { git rev-parse --abbrev-ref HEAD | tr -d '\\n'; }; f"
+	bm = branch-memo
 	brm = "branch -d"
 	ci = commit
 	cm = checkout main


### PR DESCRIPTION
## Summary

- Adds `bin/git-branch-memo` — a bash script that creates empty `memo:` commits on the current branch, with memo display scoped to `merge-base..HEAD`
- Adds `git bm` alias in `.gitconfig` as shorthand for `git branch-memo`
- Adds `/branch-memo` Claude Code skill that wraps the script with prompting and existing-memo display

## Test Plan

- [x] Run `chezmoi apply` and verify `~/bin/git-branch-memo` is present and executable
- [x] Run `git branch-memo "test note"` on a feature branch — confirm empty commit created with `memo: test note` prefix
- [x] Run `git bm "another note"` — confirm alias works
- [x] Run `/branch-memo` in Claude Code — confirm existing memos shown, message prompted, commit created
- [x] Verify `git log --oneline --grep="^memo:"` surfaces the memos

## Review Notes

Self-reviewed via deliver skill.

Standards reviewer found one MEDIUM issue (memo display scoped to full history instead of current branch) — addressed by using `merge-base HEAD origin/main..HEAD` in both the script and SKILL.md. All LOWs addressed or rebutted.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)