### PR TITLE
feat(git): add branch-cleanup script and skill

### DIFF
--- a/bin/executable_git-branch-cleanup
+++ b/bin/executable_git-branch-cleanup
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# git-branch-cleanup: analyze branches for cleanup candidates
+#
+# Usage:
+#   git branch-cleanup [-R]
+#   git bc [-R]
+#
+# Flags:
+#   -R  Also analyze remote-only branches (on origin but not local)
+#
+# Output: JSON to stdout
+#   config        Analysis parameters
+#   auto_delete   Branches with commits_ahead == 0 (all work is in main)
+#   candidates    Everything else — needs human/LLM triage
+#
+# Protected branches: main only.
+# Intentional v1 limitation: only `main` is protected. Long-running
+# branches on other names (e.g. develop, staging) are not yet handled.
+#
+# Auto-delete criterion:
+#   commits_ahead == 0
+#   The branch has no commits not reachable from main — it is fully merged
+#   (or was fast-forwarded). The sha field enables recovery via `git branch`.
+#
+# scope values:
+#   "local"   — local branch only (no tracking remote on origin)
+#   "remote"  — remote-only branch (no local counterpart)
+#   "both"    — local branch that also has an origin tracking ref
+
+set -euo pipefail
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+PROTECTED="main"
+
+# ── Flags ──────────────────────────────────────────────────────────────────────
+INCLUDE_REMOTE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -R) INCLUDE_REMOTE=true ;;
+    *)
+      printf 'unknown flag: %s\nUsage: git branch-cleanup [-R]\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+# ── Preflight ──────────────────────────────────────────────────────────────────
+git rev-parse --git-dir > /dev/null 2>&1 \
+  || { printf 'error: not inside a git repository\n' >&2; exit 1; }
+
+command -v jq > /dev/null 2>&1 \
+  || { printf 'error: jq is required (brew install jq)\n' >&2; exit 1; }
+
+git rev-parse --verify "$PROTECTED" > /dev/null 2>&1 \
+  || { printf 'error: protected branch %q not found\n' "$PROTECTED" >&2; exit 1; }
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+now=$(date +%s)
+current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+
+# Returns 0 (true) if the branch has any --allow-empty commits relative to main.
+# An empty commit has the same tree SHA as its parent. Merge commits are skipped.
+_has_empty_commits() {
+  local ref="$1"
+  while IFS= read -r hash; do
+    # Skip merge commits (2+ parents)
+    parent_count=$(git cat-file -p "$hash" | { grep -c "^parent" || true; })
+    [[ "${parent_count:-0}" -gt 1 ]] && continue
+
+    commit_tree=$(git rev-parse "${hash}^{tree}")
+    parent=$(git rev-parse "${hash}^" 2>/dev/null) || continue  # skip root commits
+    parent_tree=$(git rev-parse "${parent}^{tree}")
+
+    if [[ "$commit_tree" == "$parent_tree" ]]; then
+      return 0  # found an empty commit
+    fi
+  done < <(git rev-list "${PROTECTED}..${ref}" 2>/dev/null)
+  return 1
+}
+
+# Outputs a JSON object for one branch.
+# $1 = branch name (without origin/ prefix)
+# $2 = initial scope: "local" | "remote"
+_analyze() {
+  local name="$1" scope="$2"
+
+  # Upgrade "local" to "both" when the branch has an origin tracking ref
+  if [[ "$scope" == "local" ]]; then
+    local tracking_remote
+    tracking_remote=$(git config "branch.${name}.remote" 2>/dev/null || true)
+    if [[ "$tracking_remote" == "origin" ]] && \
+       git rev-parse --verify "origin/$name" > /dev/null 2>&1; then
+      scope="both"
+    fi
+  fi
+
+  local ref
+  [[ "$scope" == "remote" ]] && ref="origin/$name" || ref="$name"
+
+  # Tip SHA (for recovery via `git branch <name> <sha>`)
+  local sha
+  sha=$(git rev-parse "$ref" 2>/dev/null) || return
+
+  # Is this the currently checked-out branch?
+  local is_current=false
+  [[ "$name" == "$current_branch" ]] && is_current=true
+
+  # Age: use last non-memo commit so a recent memo doesn't mask a stale branch.
+  # Falls back to any commit if the branch consists entirely of memos.
+  local last_ts age_days
+  last_ts=$(
+    git log -1 --format="%ct" --invert-grep --grep="^memo:" "$ref" 2>/dev/null \
+    || git log -1 --format="%ct" "$ref" 2>/dev/null
+  ) || return
+  age_days=$(( (now - last_ts) / 86400 ))
+
+  # Commits ahead of main
+  local commits_ahead
+  commits_ahead=$(git rev-list --count "${PROTECTED}..${ref}" 2>/dev/null || echo 0)
+
+  # Lines changed vs merge-base (three-dot: what the branch uniquely contributes)
+  local diff_stat insertions deletions lines_changed
+  diff_stat=$(git diff --shortstat "${PROTECTED}...${ref}" 2>/dev/null || true)
+  insertions=$(printf '%s' "$diff_stat" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)
+  deletions=$(printf '%s' "$diff_stat"  | grep -oE '[0-9]+ deletion'  | grep -oE '[0-9]+' || echo 0)
+  lines_changed=$(( ${insertions:-0} + ${deletions:-0} ))
+
+  # Empty commits (--allow-empty), including branch-memo annotations
+  local has_empty_commits=false
+  if _has_empty_commits "$ref"; then
+    has_empty_commits=true
+  fi
+
+  # Memos (empty commits with "memo:" prefix)
+  local memos_json
+  memos_json=$(
+    git log "${PROTECTED}..${ref}" --format="%s" --grep="^memo:" 2>/dev/null \
+      | jq -Rsc '[split("\n") | .[] | select(length > 0)]'
+  )
+
+  # Most recent non-memo commit subject; fall back to most recent memo if the
+  # branch contains only annotations.
+  local recent_commit
+  recent_commit=$(
+    git log "${PROTECTED}..${ref}" --format="%s" 2>/dev/null \
+      | { grep -v "^memo:" || true; } \
+      | head -1
+  )
+  if [[ -z "$recent_commit" ]]; then
+    recent_commit=$(git log "${PROTECTED}..${ref}" --format="%s" 2>/dev/null | head -1 || true)
+  fi
+
+  jq -n \
+    --arg  name                 "$name"               \
+    --arg  scope                "$scope"              \
+    --arg  sha                  "$sha"                \
+    --argjson age_days          "$age_days"           \
+    --argjson commits_ahead     "$commits_ahead"      \
+    --argjson lines_changed     "$lines_changed"      \
+    --argjson has_empty_commits "$has_empty_commits"  \
+    --argjson memos             "$memos_json"         \
+    --arg  recent_commit        "$recent_commit"      \
+    --argjson is_current        "$is_current"         \
+    '{
+       name:              $name,
+       scope:             $scope,
+       sha:               $sha,
+       age_days:          $age_days,
+       commits_ahead:     $commits_ahead,
+       lines_changed:     $lines_changed,
+       has_empty_commits: $has_empty_commits,
+       memos:             $memos,
+       recent_commit:     $recent_commit,
+       is_current:        $is_current
+     }'
+}
+
+# ── Collect branches ───────────────────────────────────────────────────────────
+auto_delete_json="[]"
+candidates_json="[]"
+
+_add() {
+  local result="$1" commits_ahead
+  commits_ahead=$(printf '%s' "$result" | jq '.commits_ahead')
+  if [[ "$commits_ahead" -eq 0 ]]; then
+    auto_delete_json=$(printf '%s' "$auto_delete_json" | jq --argjson r "$result" '. + [$r]')
+  else
+    candidates_json=$(printf '%s' "$candidates_json" | jq --argjson r "$result" '. + [$r]')
+  fi
+}
+
+# Local branches, excluding protected
+while IFS= read -r branch; do
+  [[ -z "$branch" ]] && continue
+  result=$(_analyze "$branch" "local") || continue
+  _add "$result"
+done < <(git branch --format="%(refname:short)" | grep -vxF "$PROTECTED")
+
+# Remote-only branches (if -R): skip any that already have a local counterpart
+if $INCLUDE_REMOTE; then
+  while IFS= read -r branch; do
+    [[ -z "$branch" ]] && continue
+    git rev-parse --verify "$branch" > /dev/null 2>&1 && continue  # already local
+    result=$(_analyze "$branch" "remote") || continue
+    _add "$result"
+  done < <(
+    git branch -r --format="%(refname:short)" \
+      | grep  "^origin/" \
+      | grep -vxF "origin/${PROTECTED}" \
+      | grep -v "^origin/HEAD$" \
+      | sed 's|^origin/||'
+  )
+fi
+
+# ── Emit JSON ──────────────────────────────────────────────────────────────────
+jq -n \
+  --argjson auto_delete    "$auto_delete_json"  \
+  --argjson candidates     "$candidates_json"   \
+  --arg     protected      "$PROTECTED"         \
+  --argjson include_remote "$INCLUDE_REMOTE"    \
+  '{
+     config: {
+       protected:      [$protected],
+       include_remote: $include_remote,
+       remote_note:    "remote deletions target origin only (v1 limitation)"
+     },
+     auto_delete: $auto_delete,
+     candidates:  $candidates
+   }'

--- a/private_dot_claude/skills/branch-cleanup/SKILL.md
+++ b/private_dot_claude/skills/branch-cleanup/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: branch-cleanup
+description: This skill should be used when the user says "/branch-cleanup", "clean up branches", "prune branches", or wants to identify and delete local (and optionally remote) branches that no longer have value.
+version: 1.1.0
+---
+
+# Branch Cleanup
+
+Identify and delete branches that no longer have value. Logic lives in
+`~/bin/git-branch-cleanup` (source: `bin/executable_git-branch-cleanup` in the
+chezmoi repo); this skill handles interactive triage and deletion.
+
+## Invocation
+
+- `/branch-cleanup` — analyze and clean local branches
+- `/branch-cleanup -R` — also include remote-only branches (on origin but not local)
+- `/branch-cleanup --dry-run` / `/branch-cleanup -n` — analyze and show buckets but
+  do not delete anything
+
+## Flags
+
+| Flag | Forwarded to script? | Notes |
+|---|---|---|
+| `-R` | Yes | Adds remote-only branches to analysis |
+| `--dry-run` / `-n` | No | Consumed by this skill; suppresses all deletions |
+
+## Intentional v1 limitations
+
+- Only `main` is a protected branch. Long-running branches on other names
+  (e.g. `develop`, `staging`) are not yet auto-protected.
+- Remote deletions target the `origin` remote only.
+
+## Flow
+
+```
+Fetch → Analyze → Show buckets → Confirm → Execute
+```
+
+Show all three buckets **before** any deletion. The user must confirm before
+anything is deleted.
+
+---
+
+### Step 1: Fetch
+
+```bash
+git fetch --prune
+```
+
+This ensures remote branch data is current before analysis. Stale fetch data
+can misclassify remote-only branches.
+
+---
+
+### Step 2: Run the analysis script
+
+```bash
+git branch-cleanup [-R]
+```
+
+(The script is installed as `~/bin/git-branch-cleanup` and aliased as
+`git branch-cleanup` / `git bc` via gitconfig. Do NOT pass `--dry-run` or `-n`
+to the script — those flags are handled by this skill only.)
+
+Capture the JSON output. If the script exits non-zero, surface the error and stop.
+
+---
+
+### Step 3: Triage candidates
+
+For each branch in `candidates`, use the following signals to classify it as
+**Suggest-Delete** or **Suggest-Keep**:
+
+| Signal | Suggests Delete | Suggests Keep |
+|---|---|---|
+| `age_days` | > 60 days | < 14 days |
+| `lines_changed` | Small (< 30) | Large |
+| `has_empty_commits` | — | Yes (intentional annotation) |
+| `memos` | — | Non-empty (explicit note left by author) |
+| `recent_commit` subject | Exploratory / stale label | Active / in-progress label |
+| Branch name prefix | `wip/`, `spike/`, `tmp/`, `test/` | `feat/`, `fix/`, `refactor/` |
+| `is_current` | — | Yes — never auto-delete the current branch |
+
+Use judgment — these are heuristics, not hard rules. A branch with a memo is
+almost always Suggest-Keep regardless of age. Never put an `is_current == true`
+branch in auto_delete or Suggest-Delete.
+
+Note: `candidates` from the script are the pool from which Suggest-Delete and
+Suggest-Keep are drawn. No branch is in both.
+
+---
+
+### Step 4: Present the three buckets
+
+Show results in this order **before taking any action**:
+
+```
+── Would Auto-Delete ─────────────────────────────────────────────────────────
+  allow-colon          (local,  18d)
+  deliver-git-message  (both,   18d)  ← local + origin/deliver-git-message
+
+  All commits from these branches are already in main.
+
+  Recovery commands (copy these before confirming):
+    git branch allow-colon d3ae79e
+    git branch deliver-git-message a1b2c3d
+
+── Suggest-Delete ────────────────────────────────────────────────────────────
+  feat/old-spike  (local, 72d, 3 commits, 45 lines)
+    Last commit: "add experimental rate limiter"
+
+── Suggest-Keep ──────────────────────────────────────────────────────────────
+  feat/worktree-skill  (local, 17d, 1 commit, 266 lines)
+    Last commit: "feat(worktree): add worktree skill"
+```
+
+In `--dry-run` mode, label sections "Would Auto-Delete", "Would Suggest-Delete",
+"Would Suggest-Keep" and stop here — do not prompt or delete anything.
+
+---
+
+### Step 5: Confirm and execute auto-deletes
+
+After presenting the buckets, prompt:
+
+```
+Auto-delete these N branches? [y/N]
+```
+
+If the user says yes, delete each branch in `auto_delete` (skipping any with
+`is_current == true` — warn if skipped):
+
+Before each deletion, verify the SHA still matches (guards against the branch
+receiving new commits since analysis):
+
+```bash
+# Verify SHA hasn't changed since analysis
+current_sha=$(git rev-parse <name> 2>/dev/null || git rev-parse origin/<name> 2>/dev/null)
+# If current_sha != recorded sha: skip and warn
+
+# scope == "local"
+git branch -D <name>
+
+# scope == "both"
+git branch -D <name>
+git push origin --delete <name>
+
+# scope == "remote"
+git push origin --delete <name>
+```
+
+---
+
+### Step 6: Confirm and execute Suggest-Delete
+
+Prompt:
+
+```
+Which Suggest-Delete branches to delete? (names, 'all', or Enter to skip)
+>
+```
+
+For each named branch (or all, if 'all'), verify SHA and delete using the same
+scope logic as Step 5.
+
+---
+
+### Step 7: Review Suggest-Keep
+
+Prompt:
+
+```
+Any Suggest-Keep branches to delete? (names or Enter to skip)
+>
+```
+
+For each named branch, verify SHA and delete using the same scope logic.
+
+---
+
+### Step 8: Report
+
+Summarize:
+
+```
+Deleted 2 branches (auto), 1 branch (confirmed).
+Kept 3 branches.
+```
+
+---
+
+## Error Handling
+
+| Failure | Recovery |
+|---|---|
+| `git-branch-cleanup` not found | Remind user to run `chezmoi apply` |
+| `jq` not found | Script will error with install hint; surface it |
+| `git fetch` fails | Warn and continue — analysis will use cached remote data |
+| SHA mismatch before deletion | Skip branch, warn: "Skipping <name>: branch changed since analysis" |
+| `git branch -D` fails | Surface error; continue with remaining branches |
+| `git push origin --delete` fails | Surface error; continue with remaining branches |
+| Script exits non-zero | Show exact error output; stop |
+| `is_current == true` in auto_delete | Skip silently; note it at the end: "<name> skipped (currently checked out)" |

--- a/private_dot_gitconfig
+++ b/private_dot_gitconfig
@@ -2,6 +2,7 @@
 	add-aw = "!git diff -w --no-color | git apply --cached --ignore-whitespace"
 	amend = commit --amend
 	branchname = "!f() { git rev-parse --abbrev-ref HEAD | tr -d '\\n'; }; f"
+	bc = branch-cleanup
 	bm = branch-memo
 	brm = "branch -d"
 	ci = commit


### PR DESCRIPTION
## Summary

- Adds `bin/executable_git-branch-cleanup`: shell script that analyzes local (and optionally remote-only) branches, emitting JSON with `auto_delete` (commits_ahead == 0) and `candidates` buckets, including `scope` ("local" / "remote" / "both"), `is_current`, age from non-memo commits, and SHA for recovery
- Adds `private_dot_claude/skills/branch-cleanup/SKILL.md`: thin AI orchestrator that fetches, runs the script, triages candidates into Suggest-Delete/Suggest-Keep, shows all three buckets before any deletion, confirms with SHA verification, and executes
- Adds `bc = branch-cleanup` alias to `private_dot_gitconfig`

## Test Plan

- [ ] `chezmoi apply` and verify `git branch-cleanup` and `git bc` resolve
- [ ] Run `git bc --dry-run` — should show buckets, make no deletions
- [ ] Run `/branch-cleanup` in a repo with stale merged branches — verify auto-delete list, confirm flow, check recovery commands printed before deletion
- [ ] Run `/branch-cleanup -R` — verify remote-only branches appear, scope "both" shown for branches with tracking remotes
- [ ] Verify current branch never appears in auto-delete bucket

## Review Notes

Self-reviewed via deliver skill. Two reviewers (User Advocate, Lead Engineer) ran in parallel; 18 findings triaged — 14 addressed, 4 won't-fixed (all low-risk or intentional v1 limitations). See commit body for full list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)